### PR TITLE
ENH: test enable_RTL in qe_theme

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - pip
   - pip:
     - jupyter-book==1.0.3
-    - quantecon-book-theme==0.8.2
+    - https://github.com/QuantEcon/quantecon-book-theme@copilot/fix-291
     - sphinx-tojupyter==0.3.0
     - sphinxext-rediraffe==0.2.7
     - sphinx-reredirects==0.1.4

--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -52,6 +52,7 @@ sphinx:
         notebook_interface        : classic  # The interface interactive links will activate ["classic", "jupyterlab"]
         colab_url                 : https://colab.research.google.com
         thebe                     : false  # Add a thebe button to pages (requires the repository to run on Binder)
+      enable_RTL: True
     mathjax_path: https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
     rediraffe_redirects:
       index_toc.md: intro.md


### PR DESCRIPTION
This PR tests the new `enable_RTL` to `quantecon_book_theme`

https://github.com/QuantEcon/quantecon-book-theme/pull/292