### PR TITLE
🌐 [translation-sync] Fix broken raw GitHub URLs for CSV data files

### DIFF
--- a/.translate/state/pandas.md.yml
+++ b/.translate/state/pandas.md.yml
@@ -1,6 +1,6 @@
-source-sha: 9490497982787a5b0eb54ee1dcd73ac326d5ae04
-synced-at: "2026-03-20"
-model: unknown
-mode: RESYNC
+source-sha: 02e57a5befc2a9a081019edc748aba15e4b2f02a
+synced-at: "2026-04-09"
+model: claude-sonnet-4-6
+mode: UPDATE
 section-count: 5
-tool-version: 0.13.1
+tool-version: 0.14.0

--- a/.translate/state/python_advanced_features.md.yml
+++ b/.translate/state/python_advanced_features.md.yml
@@ -1,6 +1,6 @@
-source-sha: dcf952a9a05ba3bf8763c21d89dac3c7480b8d45
-synced-at: "2026-03-26"
+source-sha: 02e57a5befc2a9a081019edc748aba15e4b2f02a
+synced-at: "2026-04-09"
 model: claude-sonnet-4-6
 mode: UPDATE
 section-count: 7
-tool-version: 0.13.0
+tool-version: 0.14.0

--- a/lectures/pandas.md
+++ b/lectures/pandas.md
@@ -174,7 +174,7 @@ s
 ما این را از یک URL با استفاده از تابع `read_csv` در `pandas` خواهیم خواند.
 
 ```{code-cell} ipython3
-df = pd.read_csv('https://raw.githubusercontent.com/QuantEcon/lecture-python-programming/master/source/_static/lecture_specific/pandas/data/test_pwt.csv')
+df = pd.read_csv('https://raw.githubusercontent.com/QuantEcon/lecture-python-programming/main/lectures/_static/lecture_specific/pandas/data/test_pwt.csv')
 type(df)
 ```
 

--- a/lectures/python_advanced_features.md
+++ b/lectures/python_advanced_features.md
@@ -1200,7 +1200,7 @@ sum(draws)
 :label: paf_ex1
 ```
 
-کد زیر را کامل کنید و آن را با استفاده از [این فایل csv](https://raw.githubusercontent.com/QuantEcon/lecture-python-programming/master/source/_static/lecture_specific/python_advanced_features/test_table.csv) تست کنید، که فرض می‌کنیم آن را در دایرکتوری کاری فعلی خود قرار داده‌اید
+کد زیر را کامل کنید و آن را با استفاده از [این فایل csv](https://raw.githubusercontent.com/QuantEcon/lecture-python-programming/main/lectures/_static/lecture_specific/python_advanced_features/test_table.csv) تست کنید، که فرض می‌کنیم آن را در دایرکتوری کاری فعلی خود قرار داده‌اید
 
 ```{code-block} python3
 :class: no-execute


### PR DESCRIPTION
## Automated Translation Sync

This PR contains automated translations from [QuantEcon/lecture-python-programming](https://github.com/QuantEcon/lecture-python-programming).

### Source PR
**[#491 - Fix broken raw GitHub URLs for CSV data files](https://github.com/QuantEcon/lecture-python-programming/pull/491)**

### Files Updated
- ✏️ `lectures/pandas.md`
- ✏️ `.translate/state/pandas.md.yml`
- ✏️ `lectures/python_advanced_features.md`
- ✏️ `.translate/state/python_advanced_features.md.yml`

### Details
- **Source Language**: en
- **Target Language**: fa
- **Model**: claude-sonnet-4-6

---
*This PR was created automatically by the [translation action](https://github.com/quantecon/action-translation).*