### PR TITLE
ci: add rebase-translations workflow

### DIFF
--- a/.github/workflows/rebase-translations.yml
+++ b/.github/workflows/rebase-translations.yml
@@ -1,0 +1,37 @@
+# Rebase Translation PRs
+#
+# Install this workflow in the TARGET (translated) repository.
+# When a translation-sync PR is merged, this workflow automatically
+# rebases other open translation-sync PRs against the updated main branch.
+#
+# This eliminates merge conflicts caused by multiple upstream PRs
+# modifying the same files. See: https://github.com/QuantEcon/action-translation/issues/63
+#
+# Place this file at: .github/workflows/rebase-translations.yml
+
+name: Rebase Translation PRs
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  rebase:
+    # Only run when a translation-sync PR is merged
+    if: >
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'translation-sync-')
+    runs-on: ubuntu-latest
+
+    # Prevent concurrent rebases from overlapping
+    concurrency:
+      group: rebase-translations
+      cancel-in-progress: false
+
+    steps:
+      - name: Rebase conflicted translation PRs
+        uses: quantecon/action-translation@v0.15
+        with:
+          mode: rebase
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rebase-translations.yml
+++ b/.github/workflows/rebase-translations.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Rebase conflicted translation PRs
-        uses: quantecon/action-translation@v0.15
+        uses: QuantEcon/action-translation@v0.15
         with:
           mode: rebase
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/rebase-translations.yml
+++ b/.github/workflows/rebase-translations.yml
@@ -23,14 +23,18 @@ jobs:
       startsWith(github.event.pull_request.head.ref, 'translation-sync-')
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+      pull-requests: write
+
     # Prevent concurrent rebases from overlapping
     concurrency:
       group: rebase-translations
       cancel-in-progress: false
 
     steps:
-      - name: Rebase conflicted translation PRs
-        uses: QuantEcon/action-translation@v0.15
+      - name: Rebase open translation PRs
+        uses: QuantEcon/action-translation@v0.15.0
         with:
           mode: rebase
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Add rebase-translations workflow

Adds a new workflow that automatically rebases open `translation-sync-*` PRs when a sibling translation PR is merged.

### Why

When multiple upstream PRs modify the same file, the first translation PR to merge makes the others conflict (full-file replacement). This caused a **62% merge conflict rate** (issue [QuantEcon/action-translation#63](https://github.com/QuantEcon/action-translation/issues/63)).

### How it works

When a `translation-sync-*` PR is merged:
1. Finds sibling translation PRs with overlapping files
2. Re-runs the translation pipeline against updated `main`
3. **Reuses cached translations** for unchanged sections (zero Claude API calls in the common case)
4. Force-pushes the rebased result

### What's added

- `.github/workflows/rebase-translations.yml` — triggered on `pull_request.closed` for translation-sync branches
- Uses `quantecon/action-translation@v0.15` with `mode: rebase`
- Includes concurrency group to prevent overlapping rebases

See [action-translation v0.15.0 release](https://github.com/QuantEcon/action-translation/releases/tag/v0.15.0) for full details.
