### PR TITLE
chore: upgrade action-translation to v0.16.1

### DIFF
--- a/.github/workflows/rebase-translations.yml
+++ b/.github/workflows/rebase-translations.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Rebase open translation PRs
-        uses: QuantEcon/action-translation@v0.15.0
+        uses: QuantEcon/action-translation@v0.16.1
         with:
           mode: rebase
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/review-translations.yml
+++ b/.github/workflows/review-translations.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - uses: QuantEcon/action-translation@v0.15.0
+      - uses: QuantEcon/action-translation@v0.16.1
         with:
           mode: review
           source-repo: QuantEcon/lecture-python-programming


### PR DESCRIPTION
Brings `review-translations.yml` and `rebase-translations.yml` onto **v0.16.1** (both were v0.15.0).

## What v0.16.1 fixes for these two modes

- **Review — CRLF**: GitHub normalizes an edited PR body to CRLF, and the old parser only matched `\n` — so review mode broke permanently on any PR whose body had been edited.
- **Review — pagination**: `listFiles` was unpaginated (a PR touching >30 files was only partly reviewed); `listComments` was too, so past 30 comments the existing review comment wasn't found and duplicates accumulated.
- **Rebase — pagination**: `pulls.list` was capped at 100, so sibling PRs beyond that were never rebased.
- **Both — truncation detection**: a response cut off at `max_tokens` was used as if complete; it now fails loudly.

Validated before the bump: the 26-scenario e2e harness ran v0.16.1 against `test-translation-sync.fa` — 26/26 correct translation PRs, covering the RTL path specifically.

Note the companion PR in the source repo (QuantEcon/lecture-python-programming#575) moves this language's **sync** workflow to v0.16.1, which is also the Sonnet 4.6 → Sonnet 5 default-model change. This PR only affects review and rebase, which run here.

Detail: QuantEcon/action-translation#83 · [v0.16.1 release notes](https://github.com/QuantEcon/action-translation/releases/tag/v0.16.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)