### PR TITLE
Serialise translation reviews to stop duplicate report comments

### DIFF
--- a/.github/workflows/review-translations.yml
+++ b/.github/workflows/review-translations.yml
@@ -7,9 +7,34 @@ on:
   pull_request:
     types: [opened, synchronize, labeled, reopened]
 
+# Serialise reviews per PR.
+#
+# The sync action creates the PR and then applies its labels in a separate call,
+# so a single sync fires `opened` plus one `labeled` event per label, all within
+# a couple of seconds. Every one of those starts a full review, and the action's
+# "update the existing comment, else create one" logic is a check-then-act with
+# no lock — concurrent runs all observe "no comment yet" and each create one.
+# See QuantEcon/lecture-python-programming.fr#6, which collected two review
+# comments this way, and QuantEcon/action-translation#96 for the upstream bug.
+#
+# cancel-in-progress is deliberately false. The labels are applied in one API
+# call, so event ordering is not guaranteed; if 'automated' arrived last it would
+# cancel the in-flight review for 'action-translation' and then skip its own job
+# via the filter below, leaving no review at all. Queuing instead means the first
+# run creates the comment and any later run updates it — one comment, always.
+concurrency:
+  group: review-translations-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
 jobs:
   review:
-    if: contains(github.event.pull_request.labels.*.name, 'action-translation')
+    # Require the 'action-translation' label, and — for `labeled` events — ignore
+    # labels other than that one. Without the second clause the 'automated' label
+    # fires a second, redundant review of the identical diff.
+    if: >-
+      contains(github.event.pull_request.labels.*.name, 'action-translation') &&
+      (github.event.action != 'labeled' ||
+       github.event.label.name == 'action-translation')
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## What

Ports [QuantEcon/lecture-python-programming.fr#7](https://github.com/QuantEcon/lecture-python-programming.fr/pull/7) (merged) to the Farsi edition: adds a per-PR `concurrency` group to `Review Translations`, and stops `labeled` events for labels other than `action-translation` from triggering a review.

## Why

**The bug is already reproducing in this repo.** [#133](https://github.com/QuantEcon/lecture-python-programming.fa/pull/133) — the open `numba.md` sync from source PR #550 — carries two "Translation Quality Review" comments, scoring 9.2/10 and 8.8/10, both posted at 23:51:37. Both are genuine model output: the same diff reviewed twice.

The sync action creates the PR and then applies its labels in a separate call, so one sync fires `opened` plus a `labeled` event per label within a couple of seconds. Each starts its own run. The action's "update the existing comment, else create one" logic is a check-then-act with no lock, so concurrent runs all observe "no comment yet" and each create one. The run logs for #133 show exactly that:

| Run | Outcome logged |
| --- | --- |
| 29459761998 | `Posted review comment on PR #133` |
| 29459762099 | `Posted review comment on PR #133` |
| 29459762464 | `Updated existing review comment on PR #133` |

Two runs won the create race; the third found a comment and updated it. Because each comment was then overwritten by a different run, neither necessarily reflects the run that created it.

Besides the duplicate report, this is a **3x model-spend multiplier** on that PR, and it scales with the number of labels applied.

## Why `cancel-in-progress: false`

Worth reviewing carefully, because `true` is the reflex and would be wrong here. Both labels are applied in a single `addLabels` call, so the order of the resulting `labeled` events is not guaranteed. With `true`, an `automated` event arriving last would cancel the in-flight review started by `action-translation`, then skip its own job via the new label filter — leaving no review at all. Cancellation happens when the run is queued, before the job-level `if` is evaluated, so the filter cannot protect against it.

Queuing is safe in every ordering: the first run to reach the comment step creates the comment, any later run updates it.

## Scope

This fixes the symptom at the workflow layer. The unsynchronised upsert is a latent bug in the action itself, tracked as QuantEcon/action-translation#96 — any two concurrent review runs will duplicate again until that lands. `lecture-python-programming.zh-cn` triggers only on `[opened, synchronize]` and is much less exposed, so I have left it alone.

Note this does not retroactively clean up #133, which still has both comments on it.

## Verification

YAML parses, and the action inputs are unchanged (`source-language: en`, `target-language: fa`, same action pin, same secrets) — the diff is the concurrency block plus the `if` filter and comments, nothing else. The behaviour itself can only be confirmed on the next Farsi sync PR; worth watching that it produces exactly one review comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
