### PR TITLE
Rebase pushes with the machine-user PAT (action-translation#125)

### DIFF
--- a/.github/workflows/rebase-translations.yml
+++ b/.github/workflows/rebase-translations.yml
@@ -4,7 +4,7 @@
 # When a translation PR is merged, this workflow automatically rebases the
 # other open translation PRs against the updated main branch. It covers both
 # kinds this tool creates: `translation-sync-*` branches from the Action's sync
-# mode, and `resync/*` branches from the CLI's `forward --github`.
+# mode, and `resync/*` branches from the CLI's `translate forward --github`.
 #
 # This eliminates merge conflicts caused by multiple upstream PRs
 # modifying the same files. See: https://github.com/QuantEcon/action-translation/issues/63
@@ -20,7 +20,7 @@ on:
 jobs:
   rebase:
     # Only run when a translation PR is merged. Both prefixes must be listed:
-    # sync mode creates `translation-sync-*`, while the CLI's `forward --github`
+    # sync mode creates `translation-sync-*`, while the CLI's `translate forward --github`
     # creates `resync/*`, and a wave of resync PRs goes stale the same way.
     # Keep this in step with `isTranslationBranch` in the action's src/branch-naming.ts
     # — this `if` decides whether the job runs, that predicate decides which open PRs
@@ -46,4 +46,11 @@ jobs:
         with:
           mode: rebase
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # PAT rather than the default GITHUB_TOKEN, deliberately: commits pushed
+          # with GITHUB_TOKEN trigger no workflows (GitHub's recursion guard), so a
+          # rebased branch ends up with a run-less head — force-pushed re-translated
+          # content lands unreviewed, and with required checks a run-less head blocks
+          # merging. Validated both ways on the test harness, 2026-07-21: zero runs
+          # under GITHUB_TOKEN, review triggered under the PAT.
+          # See QuantEcon/action-translation#125.
+          github-token: ${{ secrets.QUANTECON_SERVICES_PAT }}


### PR DESCRIPTION
Completes the production half of [action-translation#125](https://github.com/QuantEcon/action-translation/issues/125): the rebase workflow now pushes with the machine-user PAT instead of the default `GITHUB_TOKEN`.

## Why

Commits pushed with `GITHUB_TOKEN` do not trigger workflows — GitHub's recursion guard — so a rebased branch ends up with a **run-less head**: force-pushed re-translated content lands unreviewed, and with required status checks a run-less head *blocks* merging. Measured both ways on the test harness, same repo, same day: 13 `GITHUB_TOKEN`-rebased heads with **zero** workflow runs, versus a PAT-refreshed head whose review workflow triggered normally.

This is the same reasoning sync mode has always applied — its PRs trigger the review workflow *because* it passes the PAT. Rebase pushing to the same PRs with a weaker token was an inconsistency, not a decision.

## Safety

- **No loop risk**: rebase triggers on `closed`; the runs a PAT push triggers (CI, review) never push back.
- **Fork exposure: none, including on public repos** — secrets are withheld from `pull_request` workflows triggered from forks regardless of repo visibility, and the job's `if` only matches branch prefixes the tooling creates.
- The org-secret grant for this repo is in place (a missing grant fails loudly: `Input required and not supplied: github-token`).

The harness (`test-translation-sync.zh-cn`) has carried this exact configuration in steady state since validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)