### PR TITLE
Rebase: require a same-repo head branch (fork noise guard)

### DIFF
--- a/.github/workflows/rebase-translations.yml
+++ b/.github/workflows/rebase-translations.yml
@@ -25,8 +25,13 @@ jobs:
     # Keep this in step with `isTranslationBranch` in the action's src/branch-naming.ts
     # — this `if` decides whether the job runs, that predicate decides which open PRs
     # it then rebases, so a prefix matching only one of them is a no-op run.
+    # The head-repo check is belt-and-braces: fork PRs never receive secrets, so
+    # the PAT is not exposed either way — but a merged fork PR whose branch happens
+    # to match a prefix would otherwise start this job with an empty token and fail
+    # red. Same-repo branches matching these prefixes only come from the tooling.
     if: >
       github.event.pull_request.merged == true &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
       (startsWith(github.event.pull_request.head.ref, 'translation-sync-') ||
        startsWith(github.event.pull_request.head.ref, 'resync/'))
     runs-on: ubuntu-latest


### PR DESCRIPTION
One-line hardening from Copilot's review of the PAT rollout ([.fr#17 comment](https://github.com/QuantEcon/lecture-python-programming.fr/pull/17), applied estate-wide): the rebase job now requires a same-repo head branch. Fork PRs never receive secrets — the PAT was not exposed — but a merged fork PR whose branch happened to match a translation prefix would start the job with an empty token and fail red; it is now skipped. Mirrors [action-translation#130](https://github.com/QuantEcon/action-translation/pull/130) and the harness copies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)