### PR TITLE
Generate the missing heading map for autodiff.md

### DIFF
--- a/.translate/state/autodiff.md.yml
+++ b/.translate/state/autodiff.md.yml
@@ -3,4 +3,4 @@ synced-at: "2026-04-08"
 model: claude-sonnet-4-6
 mode: NEW
 section-count: 5
-tool-version: 0.13.1
+tool-version: 0.22.0

--- a/lectures/autodiff.md
+++ b/lectures/autodiff.md
@@ -9,6 +9,25 @@ kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+translation:
+  title: ماجراهایی با مشتق‌گیری خودکار
+  headings:
+    Overview: مرور کلی
+    What is automatic differentiation?: مشتق‌گیری خودکار چیست؟
+    What is automatic differentiation?::Autodiff is not finite differences: مشتق‌گیری خودکار، تفاضل محدود نیست
+    What is automatic differentiation?::Autodiff is not symbolic calculus: مشتق‌گیری خودکار، حساب نمادین نیست
+    What is automatic differentiation?::Autodiff: مشتق‌گیری خودکار
+    Some experiments: برخی آزمایش‌ها
+    Some experiments::A differentiable function: یک تابع قابل مشتق‌گیری
+    Some experiments::Absolute value function: تابع قدر مطلق
+    Some experiments::Differentiating through control flow: مشتق‌گیری از طریق جریان کنترل
+    Some experiments::Differentiating through a linear interpolation: مشتق‌گیری از طریق درون‌یابی خطی
+    Gradient Descent: گرادیان کاهشی
+    Gradient Descent::A function for gradient descent: یک تابع برای گرادیان کاهشی
+    Gradient Descent::Simulated data: داده‌های شبیه‌سازی‌شده
+    Gradient Descent::Minimizing squared loss by gradient descent: کمینه‌سازی تابع زیان مربعات با گرادیان کاهشی
+    Gradient Descent::Adding a squared term: افزودن یک جمله مربعی
+    Exercises: تمرین‌ها
 ---
 
 # ماجراهایی با مشتق‌گیری خودکار


### PR DESCRIPTION
`lectures/autodiff.md` had no heading map in its frontmatter. It was the **only** such file in the entire five-edition estate — 248 of the 249 files with sections carry one.

| Edition | Files with sections | With heading map | Missing |
|---|---|---|---|
| lecture-python.zh-cn | 118 | 118 | 0 |
| lecture-intro.zh-cn | 46 | 46 | 0 |
| lecture-python-programming.zh-cn | 24 | 24 | 0 |
| lecture-python-programming.fr | 24 | 24 | 0 |
| **lecture-python-programming.fa** | **24** | **23** | **1** ← this file |

## Why it matters

The heading map bridges English heading IDs to translated headings — `## Overview` → `overview` on the English side, `## مرور کلی` → a different ID on this side. Sync uses it to locate the existing translation of each section. Without it, the next sync of this lecture has nothing to match against, so section-level updating degrades.

## How it was found

While auditing whether a new deterministic `headingMapCorrect` check would false-gate production PRs ([action-translation#148](https://github.com/QuantEcon/action-translation/issues/148)). The check is being introduced precisely because the old one was a model-asserted boolean that could be confidently wrong; the audit was to confirm the deterministic replacement wouldn't newly gate healthy files. It flagged exactly one file across the estate, and that file turned out to be a genuine gap rather than a false positive.

## What was done

Generated with `translate headingmap`, which compares source and target sections **by position** and makes **no LLM calls** — it is local, free and deterministic. Result: 5 top-level sections, 16 total entries, all matched cleanly (`5 matched, 5s/5t`).

A full-edition dry run reports the other 25 files `unchanged`, so the scope is exactly this one file — no incidental rewrites.

The `.translate/state/autodiff.md.yml` `tool-version` stamp moves `0.13.1` → `0.22.0` as a side effect of the state write. That field records the CLI that last wrote the state (see the 2026-07-23 finding on [project-translation#4](https://github.com/QuantEcon/project-translation/issues/4)), so the bump is accurate rather than incidental drift.

## Verification

Frontmatter YAML parses; 16 heading entries and the translated title read back correctly. Re-running the estate audit against this branch reports **0** files with sections and no heading map for the fa edition.

No content is touched — the diff is frontmatter plus the state stamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
