### PR TITLE
Enable the language switcher and fix this edition's site URLs

### DIFF
--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -8,7 +8,7 @@ execute:
   timeout: 600 # 10 minutes
 
 html:
-  baseurl: https://python-programming-fa.quantecon.org/
+  baseurl: https://quantecon.github.io/lecture-python-programming.fa/
 
 latex:
   latex_documents:
@@ -55,7 +55,8 @@ sphinx:
       header_organisation_url: https://quantecon.org
       header_organisation: QuantEcon
       repository_url: https://github.com/QuantEcon/lecture-python-programming.fa
-      nb_repository_url: https://github.com/QuantEcon/lecture-python-programming.fa.notebooks
+      # nb_repository_url omitted deliberately: no notebooks repo exists for this
+      # edition yet, and the theme skips notebook-launch links when it is unset
       path_to_docs: lectures
       twitter: quantecon
       twitter_logo_url: https://assets.quantecon.org/img/qe-twitter-logo.png
@@ -74,8 +75,8 @@ sphinx:
       index_toc.md: intro.md
     tojupyter_static_file_path: ["source/_static", "_static"]
     tojupyter_target_html: true
-    tojupyter_urlpath: "https://python-programming-fa.quantecon.org/"
-    tojupyter_image_urlpath: "https://python-programming-fa.quantecon.org/_static/"
+    tojupyter_urlpath: "https://quantecon.github.io/lecture-python-programming.fa/"
+    tojupyter_image_urlpath: "https://quantecon.github.io/lecture-python-programming.fa/_static/"
     tojupyter_lang_synonyms: ["ipython", "ipython3", "python"]
     tojupyter_kernels:
       python3:

--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -32,6 +32,20 @@ sphinx:
     html_theme: quantecon_book_theme
     html_static_path: ['_static']
     html_theme_options:
+      languages:
+        - code: en
+          name: English
+          url: https://python-programming.quantecon.org
+        - code: fa
+          name: فارسی
+          url: https://quantecon.github.io/lecture-python-programming.fa
+        - code: fr
+          name: Français
+          url: https://quantecon.github.io/lecture-python-programming.fr
+        - code: zh-cn
+          name: 中文
+          url: https://quantecon.github.io/lecture-python-programming.zh-cn
+      current_language: fa
       authors:
         - name: Thomas J. Sargent
           url: http://www.tomsargent.com/


### PR DESCRIPTION
Two related changes: enable the language switcher, and point this edition's URLs at the address it is actually served from. The second is a prerequisite for the first to be worth anything, which is why they are together — see below.

## 1. Language switcher

Adds the switcher configuration to `html_theme_options`, mirroring QuantEcon/lecture-python-programming#490 which adds the same block to the English source.

| Code | Name | URL |
|---|---|---|
| `en` | English | https://python-programming.quantecon.org |
| `fa` | فارسی | https://quantecon.github.io/lecture-python-programming.fa |
| `fr` | Français | https://quantecon.github.io/lecture-python-programming.fr |
| `zh-cn` | 中文 | https://quantecon.github.io/lecture-python-programming.zh-cn |

`current_language: fa`, so this edition renders as active. English stays first because the theme uses `languages[0]` as the `hreflang` `x-default` target.

This does not propagate from the English source: the sync workflows trigger only on `lectures/**/*.md` and `lectures/_toc.yml`, so `_config.yml` never reaches a sync run, and each edition needs its own `current_language` anyway.

## 2. Site URLs

`html.baseurl` was `https://python-programming-fa.quantecon.org/`, and that host **does not resolve** — DNS fails. Every page emitted a `canonical` and an `og:url` pointing at a dead address, while the site actually serves from `https://quantecon.github.io/lecture-python-programming.fa/`. Both `tojupyter_urlpath` and `tojupyter_image_urlpath` carried the same dead host, so generated notebooks resolved their links and images there too.

This edition is hosted at its GitHub Pages URL while the broader URL structure is worked out, so all three now say that.

This matters for part 1 rather than being incidental to it. Search engines reconcile `hreflang` against each page's canonical; with the canonical pointing somewhere unreachable, the annotations could not form a valid cluster and the SEO half of the switcher would have been inert.

Also drops `nb_repository_url`, which pointed at `lecture-python-programming.fa.notebooks` — a repository that does not exist. Replaced with the same explanatory comment the `fr` edition already carries; the theme omits notebook-launch links when the option is unset, which is how `.fr` runs in production today.

## Verification

Built locally against `quantecon-book-theme==0.21.0`, which this repo already pins:

- The switcher lists all four languages with **فارسی active**.
- `dir="rtl"` is preserved on `<body>` — `enable_rtl: True` is untouched.
- `hreflang` alternates inject, including `x-default` → en.
- `canonical` and `og:url` now read `https://quantecon.github.io/lecture-python-programming.fa/{page}.html`, matching this edition's own `hreflang` self-reference. That agreement is what makes the cluster coherent.

## Note

Nothing here changes a live page until a `publish*` tag is pushed. This edition last published on 2026-06-19.
