### PR TITLE
Run the review auto-merge gate in shadow mode (Stage 4 calibration)

### DIFF
--- a/.github/workflows/review-translations.yml
+++ b/.github/workflows/review-translations.yml
@@ -51,5 +51,9 @@ jobs:
           source-language: en
           target-language: fa
           docs-folder: lectures
+          # Stage 4 shadow calibration (QuantEcon/project-translation#15): records
+          # the would-auto-merge decision in the verdict block, a run notice and an
+          # output — and acts on none of them. Routing and labels are unchanged.
+          auto-merge-mode: shadow
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
One-line workflow change: review mode now passes `auto-merge-mode: shadow` to action-translation.

**Nothing observable changes for this repo.** Shadow computes the would-auto-merge decision on every review and records it in three places — the `translation-review-verdict` block (`wouldAutoMerge: true|false`), a workflow notice in the run log, and a `would-auto-merge` action output — and acts on none of them. No PR is merged by machine, no label or routing changes; sync PRs keep going to editors exactly as today.

**Why**: Stage 4 of the human-review optimisation program (QuantEcon/project-translation#15) needs ≥4 weeks of recorded decisions on real sync traffic to measure the gate's base rate (how often it would fire) and precision (whether it would have been right) before the per-criterion floors are set — the floors shipped in verdict v2 are provisional placeholders, and shadow data is what replaces them. Merging this PR starts this edition's calibration window.

**Safety**: the mechanism shipped in v0.22.0 default-off, is fail-closed throughout (a malformed verdict gates to `editor`, never to merge), and was field-validated on the test harness at v0.25.0 on 2026-08-04 — the deployed-path run recorded `wouldAutoMerge: true` and took no action (validation record on QuantEcon/project-translation#15). `active` is deliberately unimplemented and fails loudly. Reverting is deleting one input line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
